### PR TITLE
Rust has changed to_str to to_string

### DIFF
--- a/src/macro.rs
+++ b/src/macro.rs
@@ -87,7 +87,7 @@ impl Parsed {
     fn struct_fields(&self, cx: &ExtCtxt) -> Vec<ast::StructField> {
         let mut fields: Vec<ast::StructField> = vec!();
         for (atom, opts) in self.doc.p.descs.iter() {
-            let name = ValueMap::key_to_struct_field(atom.to_str().as_slice());
+            let name = ValueMap::key_to_struct_field(atom.to_string().as_slice());
             let ty = match self.types.find(atom) {
                 None => self.pat_type(cx, atom, opts),
                 Some(ty) => ty.clone(),
@@ -162,7 +162,7 @@ impl<'a, 'b> MacParser<'a, 'b> {
             &token::EOF, sep, |p| MacParser::parse_type_annotation(p)
         ).move_iter()
          .map(|(ident, ty)| {
-             let field_name = token::get_ident(ident).to_str();
+             let field_name = token::get_ident(ident).to_string();
              let key = ValueMap::struct_field_to_key(field_name.as_slice());
              (Atom::new(key.as_slice()), ty)
           })
@@ -198,18 +198,18 @@ impl<'a, 'b> MacParser<'a, 'b> {
                 _ => false,
             }
         }
-        fn lit_to_str(lit: Gc<ast::Lit>) -> String {
+        fn lit_to_string(lit: Gc<ast::Lit>) -> String {
             match lit.node {
-                ast::LitStr(ref s, _) => s.to_str(),
+                ast::LitStr(ref s, _) => s.to_string(),
                 _ => fail!("BUG: expected string literal"),
             }
         }
         let exp = self.cx.expand_expr(self.p.parse_expr());
         let s = match exp.node {
-            ast::ExprLit(lit) if lit_is_str(lit) => lit_to_str(lit),
+            ast::ExprLit(lit) if lit_is_str(lit) => lit_to_string(lit),
             _ => {
                 let err = format!("Expected string literal but got {}",
-                                  pprust::expr_to_str(exp));
+                                  pprust::expr_to_string(exp));
                 self.cx.span_err(exp.span, err.as_slice());
                 return Err(());
             }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,7 +15,7 @@
 //   - The core matching algorithm is reasonably simple and concise, but I
 //     think writing down some contracts will help me figure out how to make
 //     the code clearer.
-// 
+//
 // Some bad things:
 //
 //   - I tried several times to split some of the pieces in this module into
@@ -33,7 +33,7 @@
 //
 //   - Document representation and invariants.
 //   - Less important: write contracts for functions.
-// 
+//
 // Long term:
 //
 //   - Write a specification for Docopt.
@@ -319,7 +319,7 @@ impl<'a> PatParser<'a> {
     }
 
     fn parse(&mut self) -> Result<Pattern, String> {
-        // let mut seen = HashSet::new(); 
+        // let mut seen = HashSet::new();
         let mut p = try!(self.pattern());
         match self.expecting.pop() {
             None => {},
@@ -380,12 +380,12 @@ impl<'a> PatParser<'a> {
                 "[" => {
                     // Check for special '[options]' shortcut.
                     if self.atis(1, "options") && self.atis(2, "]") {
-                        // let atoms = self.dopt.options_atoms(); 
-                        // let opts = Optional(atoms.move_iter().map(Atom).collect()); 
+                        // let atoms = self.dopt.options_atoms();
+                        // let opts = Optional(atoms.move_iter().map(Atom).collect());
                         self.next(); // cur == options
                         self.next(); // cur == ]
                         self.next();
-                        // seq.push(self.maybe_repeat(opts)); 
+                        // seq.push(self.maybe_repeat(opts));
                         seq.push(self.maybe_repeat(Optional(vec!())));
                         continue
                     }
@@ -588,7 +588,7 @@ pub enum Atom {
 #[deriving(Clone, Show)]
 pub struct Options {
     /// Set to true if this atom is ever repeated in any context.
-    /// For positional arguments, non-argument flags and commands, repetition 
+    /// For positional arguments, non-argument flags and commands, repetition
     /// means that they become countable.
     /// For flags with arguments, repetition means multiple distinct values
     /// can be specified (and are represented as a Vec).
@@ -1028,9 +1028,9 @@ impl<'a, 'b> Matcher<'a, 'b> {
 
                 // Build a synonym map so that it's easier to look up values.
                 let mut synmap: SynonymMap<String, Value> =
-                    s.vals.move_iter().map(|(k, v)| (k.to_str(), v)).collect();
+                    s.vals.move_iter().map(|(k, v)| (k.to_string(), v)).collect();
                 for (from, to) in argv.dopt.descs.synonyms() {
-                    let (from, to) = (from.to_str(), to.to_str());
+                    let (from, to) = (from.to_string(), to.to_string());
                     if synmap.contains_key(&to) {
                         synmap.insert_synonym(from, to);
                     }

--- a/src/synonym.rs
+++ b/src/synonym.rs
@@ -114,6 +114,6 @@ impl<K: Eq + Hash + Clone, V> FromIterator<(K, V)> for SynonymMap<K, V> {
 impl<K: Eq + Hash + Show, V: Show> Show for SynonymMap<K, V> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         try!(self.vals.fmt(f));
-        write!(f, " (synomyns: {})", self.syns.to_str())
+        write!(f, " (synomyns: {})", self.syns.to_string())
     }
 }


### PR DESCRIPTION
Update to_str to to_string to prevent the compiler
from erroring due to missing symbols etc.

I've also changed lit_to_str to lit_to_string to match, but I haven't
changed lit_is_str to match.  I'm not sure what is right, I'm just
trying to use the module.  When I know more I guess I'll have an
opinion.

Fixes compilation with:
$ rustc --version
rustc 0.11.0-nightly (1c711db551b9a5e56ba76e002e287dcfbb2cff3c 2014-07-09 00:36:40 +0000)
