### PR TITLE
Push failure to consumers instead of built-in

### DIFF
--- a/docopt_macros/src/macro.rs
+++ b/docopt_macros/src/macro.rs
@@ -68,8 +68,10 @@ impl Parsed {
             impl docopt::FlagParser for $struct_name {
                 #[allow(dead_code)]
                 fn parse_args(conf: docopt::Config, args: &[&str])
-                             -> $struct_name {
-                    docopt::docopt_args(conf, args, $full_doc).decode_must()
+                             -> Result<$struct_name, docopt::Error> {
+                    docopt::docopt_args(conf, args, $full_doc).and_then(|v| {
+                        v.decode()
+                    })
                 }
             }
         ).unwrap());

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -9,6 +9,6 @@ use docopt::FlagParser;
 docopt!(Args, "Usage: add <x> <y>", arg_x: int, arg_y: int)
 
 fn main() {
-    let args: Args = FlagParser::parse();
+    let args: Args = FlagParser::parse().unwrap();
     println!("x: {:d}, y: {:d}", args.arg_x, args.arg_y);
 }

--- a/examples/cp.rs
+++ b/examples/cp.rs
@@ -17,6 +17,6 @@ Options:
 ")
 
 fn main() {
-    let args: Args = FlagParser::parse();
+    let args: Args = FlagParser::parse().unwrap();
     println!("{}", args);
 }

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -26,7 +26,7 @@ Options:
 ", arg_x: Option<int>, arg_y: Option<int>, flag_speed: int)
 
 fn main() {
-    let args: Args = FlagParser::parse();
+    let args: Args = FlagParser::parse().unwrap();
     println!("{}", args);
 
     println!("\nSome values:");

--- a/examples/rustc.rs
+++ b/examples/rustc.rs
@@ -35,6 +35,6 @@ impl<E, D: serialize::Decoder<E>> serialize::Decodable<D, E> for OptLevel {
 }
 
 fn main() {
-    let args: Args = FlagParser::parse();
+    let args: Args = FlagParser::parse().unwrap();
     println!("{}", args);
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1021,7 +1021,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
             .filter(|s| m.state_has_valid_flags(s))
             .filter(|s| m.state_valid_num_flags(s))
             .collect::<Vec<MState>>()
-            .shift()
+            .remove(0)
             .map(|mut s| {
                 m.add_flag_values(&mut s);
                 m.add_default_values(&mut s);


### PR DESCRIPTION
Currently it does not appear to be a way to parse a structure defined by the
docopt! macro without failing the task on error. it is possible to parse without
failing using the `Docopt` structure, but this require the documentation string
which would otherwise have to be duplicated. Going down the rabbit hole ends up
meaning that most "convenient" functionality is all tied up with failure.

This commit alters top-level `docopt*` functions and the `FlagParser` functions
to all return `Result<T, docopt::Error>`. The `Error` type was enhanced with a
few new variants:
- Help - indicates that the "error" is that the specified help message should be
       printed
- Version - indicates that the program should immediately print the version and
          exit
- WithProgramUsage - indicates that the specified error caused parsing/decoding
                   to fail and that the usage string should be printed
                   afterwards.

With this, the new version of a succinct example is:

```
let args: Args = match docopt::docopt(doc) {
    Ok(args) => args,
    Err(e) => e.exit(),
};
```

I'm unsure if this is the best design for a change such as this. Results are
tempting to `unwrap` if you don't care about the error value within, but there
are some error variants that shouldn't cause the program to fail with an invalid
exit code.
