### PR TITLE
Add in required error implementation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -846,6 +846,9 @@ impl<'a> serialize::Decoder<Error> for Decoder<'a> {
                            -> Result<T, Error> {
         unimplemented!()
     }
+    fn error(&mut self, err: &str) -> Error {
+        unimplemented!()
+    }
 }
 
 pub trait FlagParser {


### PR DESCRIPTION
This doesn't do anything, but at least docopt.rs can compile.

Fixes #9.
