### PR TITLE
Rust is now supported on Travis CI!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,1 @@
-language: c
-install:
-  - curl -O http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-  - tar xfz rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-  - (cd rust-nightly-x86_64-unknown-linux-gnu/ && sudo ./install.sh)
-script:
-  - make test
-
+language: rust


### PR DESCRIPTION
The single line `-language: rust` implies:
- installation of rust-nighlty and Cargo-nightly,
- execution of

```
rustc --version
cargo --version
cargo build --verbose
cargo test --verbose
```
