### PR TITLE
Tweak the two Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,3 @@
 name = "docopt"
 version = "0.6.3"
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
-
-[lib]
-name = "docopt"
-path = "src/lib.rs"
-crate_type = ["dylib", "rlib"]

--- a/docopt_macros/Cargo.toml
+++ b/docopt_macros/Cargo.toml
@@ -9,4 +9,4 @@ path = "src/macro.rs"
 plugin = true
 
 [dependencies.docopt]
-git = "https://github.com/docopt/docopt.rs"
+path = ".."


### PR DESCRIPTION
- The docopt library doesn't need to specify that it is built as a dylib, that's
  generally an end-user decision which cargo will allow.
- Use a path dependency instead of a git dependency so docopt_macros always uses
  the local version of docopt when building
