### PR TITLE
Remove reference to libdebug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,6 @@
 #![allow(dead_code, unused_variable, unused_imports)]
 #![feature(plugin_registrar, macro_rules, phase, quote)]
 
-extern crate debug;
 extern crate libc;
 // #[cfg(test)]
 #[phase(plugin, link)]


### PR DESCRIPTION
libdebug is gone from rust-nightly, so the `extern crate` statement breaks the build.

Since there were no uses of libdebug (at least, everything compiled and the tests passed), removing the statement was enough to fix the build.
