### PR TITLE
Added 'use std::num::NumCast' to support removal from rust prelude in co...

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,7 @@ use std::error::FromError;
 use std::fmt;
 use std::from_str::{FromStr, from_str};
 use std::num;
+use std::num::NumCast;
 use serialize::Decodable;
 use parse::Parser;
 use synonym::SynonymMap;


### PR DESCRIPTION
...mmit e965ba85ca689ad77f63b7f0af9d7e337dcb4825 on rust master.

rust master removed many numeric traits from the prelude.  This changes fixes docopt.rs to work with that commit.
