### PR TITLE
Update to Rust master: String conversion updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::error::FromError;
 use std::fmt;
-use std::from_str::{FromStr, from_str};
+use std::str::{FromStr, from_str};
 use std::num;
 use std::num::NumCast;
 use serialize::Decodable;


### PR DESCRIPTION
In rust-lang/rust@29bc9c632eda71c6b4a8b35db637971953b58d03 / rust-lang/rust#18976 `FromStr, from_str` have been moved to `std::str`.
