### PR TITLE
fix parse_ty invocation (it accepts no arguments now)

### DIFF
--- a/docopt_macros/src/macro.rs
+++ b/docopt_macros/src/macro.rs
@@ -238,7 +238,7 @@ impl<'a, 'b> MacParser<'a, 'b> {
     fn parse_type_annotation(p: &mut Parser) -> (ast::Ident, P<ast::Ty>) {
         let ident = p.parse_ident();
         p.expect(&token::Colon);
-        let ty = p.parse_ty(false);
+        let ty = p.parse_ty();
         (ident, ty)
     }
 


### PR DESCRIPTION
Fix compilation. Failure on `quote_ty!` should be fixed by rust-lang/rust#19387.
