### PR TITLE
Travis should also test docopt_macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: rust
+
+script:
+ - cargo build --verbose
+ - cargo test --verbose
+ - cd docopt_macros
+ - cargo build --verbose
+ - cargo test --verbose


### PR DESCRIPTION
Right now, travis passes, but docopt_macros doesn't build. This doesn't fix docopt_macros, but it does add testing to travis.
