### PR TITLE
Move regex dependency to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ name = "docopt-wordlist"
 path = "src/wordlist.rs"
 doc = false
 test = false
+
+[dependencies]
+regex = "0.1.0"


### PR DESCRIPTION
The in-tree version is now deprecated.
