### PR TITLE
Allow single dash [-] flag in predefined struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,7 +695,7 @@ impl ArgvMap {
         let name =
             if field.starts_with("flag_") {
                 let name = regex!(r"^flag_").replace(field, "");
-                let mut pre_name = (if name.len() == 1 { "-" } else { "--" })
+                let mut pre_name = (if name.len() <= 1 { "-" } else { "--" })
                                    .to_string();
                 pre_name.push_str(name.as_slice());
                 pre_name


### PR DESCRIPTION
The standard docopts API allows you to use a single dash `[-]` (usually to indicated STDIN instead of provided filename). This shouldn't really break anything (passes all tests I ran) and allows a single dash flag indicated by `flag_`.
