### PR TITLE
Change regex for usage section

### DIFF
--- a/src/test/testcases.rs
+++ b/src/test/testcases.rs
@@ -643,3 +643,7 @@ test_expect!(test_178_testcases, "Usage: prog [-a] [--] [<arg>...]", &["-a", "--
 
 test_expect!(test_179_testcases, "Usage: prog [-a] [--] [<arg>...]", &["--", "-a"], vec!(("--", Switch(true)), ("<arg>", List(vec!("-a".to_string()))), ("-a", Switch(false))));
 
+test_expect!(test_180_testcases, "Usage: prog arg-prog", &["arg-prog"], vec!(("arg-prog", Switch(true))));
+
+test_expect!(test_181_testcases, "Usage: prog --opt-prog", &["--opt-prog"], vec!(("--opt-prog", Switch(true))));
+


### PR DESCRIPTION
I fixed #48 and added some testcases. Basically, the regex was pretty "naive" and was searching until it found the program's name. Now, it looks for the program's name at the line's start and then grabs everything until its end. That means that the regex is no longer multiline.
