### PR TITLE
Bandaid fixes for various problems arrising from orphan checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ test = false
 
 [dependencies]
 regex = "*"
-rustc-serialize = "*"
+
+[dependencies.rustc-serialize]
+git = "https://github.com/rust-lang/rustc-serialize"

--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -1,3 +1,5 @@
+#![feature(old_orphan_check)]
+
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 
@@ -30,7 +32,7 @@ Some common cargo commands are:
 See 'cargo help <command>' for more information on a specific command.
 ";
 
-#[deriving(RustcDecodable, Show)]
+#[derive(RustcDecodable, Show)]
 struct Args {
     arg_command: Command,
     arg_args: Vec<String>,
@@ -38,7 +40,7 @@ struct Args {
     flag_verbose: bool,
 }
 
-#[deriving(RustcDecodable, Show)]
+#[derive(RustcDecodable, Show)]
 enum Command {
     Build, Clean, Doc, New, Run, Test, Bench, Update,
 }

--- a/examples/cp.rs
+++ b/examples/cp.rs
@@ -1,3 +1,5 @@
+#![feature(old_orphan_check)]
+
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 
@@ -12,7 +14,7 @@ Options:
     -a, --archive  Copy everything.
 ";
 
-#[deriving(RustcDecodable, Show)]
+#[derive(RustcDecodable, Show)]
 struct Args {
     arg_source: Vec<String>,
     arg_dest: String,

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,3 +1,5 @@
+#![feature(old_orphan_check)]
+
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 
@@ -22,7 +24,7 @@ Options:
   --drifting    Drifting mine.
 ";
 
-#[deriving(RustcDecodable, Show)]
+#[derive(RustcDecodable, Show)]
 struct Args {
     flag_speed: int,
     flag_drifting: bool,

--- a/examples/verbose_multiple.rs
+++ b/examples/verbose_multiple.rs
@@ -1,3 +1,5 @@
+#![feature(old_orphan_check)]
+
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 
@@ -19,7 +21,7 @@ Options:
     -v, --verbose  Show extra log output.
 ";
 
-#[deriving(RustcDecodable, Show)]
+#[derive(RustcDecodable, Show)]
 struct Args {
     arg_source: Vec<String>,
     arg_dest: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! usage string. Here's a simple example:
 //!
 //! ```rust
+//! #![feature(old_orphan_check)]
 //! use docopt::Docopt;
 //!
 //! // Write the Docopt usage string.
@@ -46,6 +47,7 @@
 //! Here is the same example as above using type based decoding:
 //!
 //! ```rust
+//! #![feature(old_orphan_check)]
 //! # extern crate docopt;
 //! # extern crate "rustc-serialize" as rustc_serialize;
 //! # fn main() {
@@ -60,7 +62,7 @@
 //!     -a, --archive  Copy everything.
 //! ";
 //!
-//! #[deriving(RustcDecodable)]
+//! #[derive(RustcDecodable)]
 //! struct Args {
 //!     arg_source: Vec<String>,
 //!     arg_dest: String,
@@ -88,6 +90,7 @@
 //! shows more of Docopt and some of the benefits of type based decoding.
 //!
 //! ```rust
+//! #![feature(old_orphan_check)]
 //! # extern crate docopt;
 //! # extern crate "rustc-serialize" as rustc_serialize;
 //! # fn main() {
@@ -109,7 +112,7 @@
 //!     --opt-level LEVEL  Optimize with possible levels 0-3.
 //! ";
 //!
-//! #[deriving(RustcDecodable)]
+//! #[derive(RustcDecodable)]
 //! struct Args {
 //!     arg_INPUT: String,
 //!     flag_emit: Option<Emit>,
@@ -122,14 +125,14 @@
 //!
 //! // This is easy. The decoder will automatically restrict values to
 //! // strings that match one of the enum variants.
-//! #[deriving(RustcDecodable)]
-//! # #[deriving(PartialEq, Show)]
+//! #[derive(RustcDecodable)]
+//! # #[derive(PartialEq, Show)]
 //! enum Emit { Asm, Ir, Bc, Obj, Link }
 //!
 //! // This one is harder because we want the user to specify an integer,
 //! // but restrict it to a specific range. So we implement `Decodable`
 //! // ourselves.
-//! # #[deriving(PartialEq, Show)]
+//! # #[derive(PartialEq, Show)]
 //! enum OptLevel { Zero, One, Two, Three }
 //!
 //! impl<E, D> rustc_serialize::Decodable<D, E> for OptLevel
@@ -216,6 +219,7 @@
 #![experimental]
 #![deny(missing_docs)]
 #![feature(macro_rules)]
+#![feature(old_orphan_check)]
 
 extern crate libc;
 extern crate regex;
@@ -420,7 +424,7 @@ impl<'a> StrAllocating for &'a str {
 /// The main Docopt type, which is constructed with a Docopt usage string.
 ///
 /// This can be used to match command line arguments to produce a `ArgvMap`.
-#[deriving(Clone, Show)]
+#[derive(Clone, Show)]
 pub struct Docopt {
     p: Parser,
     argv: Option<Vec<String>>,
@@ -576,7 +580,7 @@ impl Docopt {
 /// `-f` for a short flag. (If `-f` is a synonym for `--flag`, then either
 /// key will work.) `ARG` or `<arg>` specify a positional argument and `cmd`
 /// specifies a command.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct ArgvMap {
     map: SynonymMap<String, Value>,
 }
@@ -596,6 +600,7 @@ impl ArgvMap {
     /// # Example
     ///
     /// ```rust
+    /// #![feature(old_orphan_check)]
     /// # extern crate docopt;
     /// # extern crate "rustc-serialize" as rustc_serialize;
     /// # fn main() {
@@ -609,7 +614,7 @@ impl ArgvMap {
     ///          -h, --help
     /// ";
     ///
-    /// #[deriving(RustcDecodable)]
+    /// #[derive(RustcDecodable)]
     /// struct Args {
     ///   cmd_build: bool,
     ///   cmd_test: bool,
@@ -778,7 +783,7 @@ impl fmt::Show for ArgvMap {
 ///
 /// The various `as_{bool,count,str,vec}` methods provide convenient access
 /// to values without destructuring manually.
-#[deriving(Clone, PartialEq, Show)]
+#[derive(Clone, PartialEq, Show)]
 pub enum Value {
     /// A boolean value from a flag that has no argument.
     ///
@@ -881,7 +886,7 @@ pub struct Decoder {
     stack: Vec<DecoderItem>,
 }
 
-#[deriving(Show)]
+#[derive(Show)]
 struct DecoderItem {
     key: String,
     struct_field: String,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -43,18 +43,19 @@ use self::Pattern::{Alternates,Sequence,Optional,Repeat,PatAtom};
 
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry::{Vacant, Occupied};
+use std::cmp::Ordering;
 use std::fmt;
 use regex;
 use regex::Regex;
 
-use Value::{mod, Switch, Counted, Plain, List};
+use Value::{self, Switch, Counted, Plain, List};
 use synonym::SynonymMap;
 
 macro_rules! err(
     ($($arg:tt)*) => (return Err(format!($($arg)*)))
 );
 
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct Parser {
     pub program: String,
     pub full_doc: String,
@@ -584,7 +585,7 @@ impl<'a> PatParser<'a> {
     }
 }
 
-#[deriving(Clone, Show)]
+#[derive(Clone, Show)]
 enum Pattern {
     Alternates(Vec<Pattern>),
     Sequence(Vec<Pattern>),
@@ -593,7 +594,7 @@ enum Pattern {
     PatAtom(Atom),
 }
 
-#[deriving(PartialEq, Eq, Ord, Hash, Clone)]
+#[derive(PartialEq, Eq, Ord, Hash, Clone)]
 pub enum Atom {
     Short(char),
     Long(String),
@@ -601,7 +602,7 @@ pub enum Atom {
     Positional(String),
 }
 
-#[deriving(Clone, Show)]
+#[derive(Clone, Show)]
 pub struct Options {
     /// Set to true if this atom is ever repeated in any context.
     /// For positional arguments, non-argument flags and commands, repetition
@@ -619,7 +620,7 @@ pub struct Options {
     pub is_desc: bool,
 }
 
-#[deriving(Clone, Show, PartialEq)]
+#[derive(Clone, Show, PartialEq)]
 pub enum Argument {
     Zero,
     One(Option<String>), // optional default value
@@ -807,7 +808,7 @@ pub struct Argv<'a> {
     options_first: bool,
 }
 
-#[deriving(Clone, Show)]
+#[derive(Clone, Show)]
 struct ArgvToken {
     atom: Atom,
     arg: Option<String>,
@@ -940,7 +941,7 @@ struct Matcher<'a, 'b:'a> {
     argv: &'a Argv<'b>,
 }
 
-#[deriving(Clone, PartialEq, Show)]
+#[derive(Clone, PartialEq, Show)]
 struct MState {
     argvi: uint, // index into Argv.positional
     counts: HashMap<Atom, uint>, // flags remaining for pattern consumption

--- a/src/synonym.rs
+++ b/src/synonym.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 use std::collections::hash_map::{Iter, Keys};
 use std::fmt::Show;
 use std::hash::Hash;
+use std::iter::FromIterator;
 use std::mem;
 
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct SynonymMap<K, V> {
     vals: HashMap<K, V>,
     syns: HashMap<K, K>,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use {Docopt, ArgvMap};
-use Value::{mod, Switch, Plain};
+use Value::{self, Switch, Plain};
 
 fn get_args(doc: &str, argv: &[&'static str]) -> ArgvMap {
     let dopt =

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -1,5 +1,6 @@
 #![experimental]
 #![feature(macro_rules)]
+#![feature(old_orphan_check)]
 
 extern crate regex;
 extern crate "rustc-serialize" as rustc_serialize;
@@ -44,7 +45,7 @@ Which will only include 'a', 'b' and 'c' in the wordlist if
 'your-command --help' contains a positional argument named 'arg'.
 ";
 
-#[deriving(RustcDecodable, Show)]
+#[derive(RustcDecodable, Show)]
 struct Args {
     arg_name: Vec<String>,
     arg_possibles: Vec<String>,


### PR DESCRIPTION
See https://github.com/rust-lang/rust/commit/c61a0092bc236c4be4cb691fcd50ff50e91ab0d6

This is simply a bandaid fix by adding `#![feature(old_orphan_check)]` in various places. 

NB. You'll notice swapping to using serialize on git instead of crates.io; that's because serialize is still broken. I personally don't see the value in depending on crates.io dependencies pre 1.0, as they break every single day, but /shrug; feel free to clone this PR branch and revert to the crates.io version if you like.