### PR TITLE
Update to rust master

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ impl Docopt {
     /// program. e.g., `["cp", "src", "dest"]` is right while `["src", "dest"]`
     /// is wrong.
     pub fn argv<I, S>(mut self, argv: I) -> Docopt
-               where I: Iterator<S>, S: StrAllocating {
+               where I: Iterator<Item=S>, S: StrAllocating {
         self.argv = Some(argv.skip(1).map(|s| s.into_str()).collect());
         self
     }

--- a/src/synonym.rs
+++ b/src/synonym.rs
@@ -89,7 +89,7 @@ impl<K: Eq + Hash + Clone, V> SynonymMap<K, V> {
 }
 
 impl<K: Eq + Hash + Clone, V> FromIterator<(K, V)> for SynonymMap<K, V> {
-    fn from_iter<T: Iterator<(K, V)>>(mut iter: T) -> SynonymMap<K, V> {
+    fn from_iter<T: Iterator<Item=(K, V)>>(mut iter: T) -> SynonymMap<K, V> {
         let mut map = SynonymMap::new();
         for (k, v) in iter {
             map.insert(k, v);


### PR DESCRIPTION
Various fixes for `Iterator` (breaking change [here](https://github.com/rust-lang/rust/commit/c6c786671d692d7b13c2e5c68a53001327b4b125)).

This PR, when merged with #71, compiles and tests just fine (of course, with some warnings).