### PR TITLE
Update for Rustup

### DIFF
--- a/docopt_macros/examples/add.rs
+++ b/docopt_macros/examples/add.rs
@@ -5,7 +5,7 @@ extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 #[plugin] extern crate docopt_macros;
 
-docopt!(Args, "Usage: add <x> <y>", arg_x: int, arg_y: int);
+docopt!(Args, "Usage: add <x> <y>", arg_x: usize, arg_y: usize);
 
 fn main() {
     let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());

--- a/docopt_macros/examples/cp.rs
+++ b/docopt_macros/examples/cp.rs
@@ -17,5 +17,5 @@ Options:
 
 fn main() {
     let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
-    println!("{}", args);
+    println!("{:?}", args);
 }

--- a/docopt_macros/examples/macro.rs
+++ b/docopt_macros/examples/macro.rs
@@ -22,14 +22,14 @@ Options:
   --speed=<kn>  Speed in knots [default: 10].
   --moored      Moored (anchored) mine.
   --drifting    Drifting mine.
-", arg_x: Option<int>, arg_y: Option<int>, flag_speed: int);
+", arg_x: Option<usize>, arg_y: Option<usize>, flag_speed: usize);
 
 fn main() {
     let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
-    println!("{}", args);
+    println!("{:?}", args);
 
     println!("\nSome values:");
     println!("  Speed: {}", args.flag_speed);
     println!("  Drifting? {}", args.flag_drifting);
-    println!("  Names: {}", args.arg_name);
+    println!("  Names: {:?}", args.arg_name);
 }

--- a/docopt_macros/examples/rustc.rs
+++ b/docopt_macros/examples/rustc.rs
@@ -27,7 +27,7 @@ enum OptLevel { Zero, One, Two, Three }
 
 impl rustc_serialize::Decodable for OptLevel {
     fn decode<D: rustc_serialize::Decoder>(d: &mut D) -> Result<OptLevel, D::Error> {
-        Ok(match try!(d.read_uint()) {
+        Ok(match try!(d.read_usize()) {
             0 => OptLevel::Zero, 1 => OptLevel::One,
             2 => OptLevel::Two, 3 => OptLevel::Three,
             n => {
@@ -40,5 +40,5 @@ impl rustc_serialize::Decodable for OptLevel {
 
 fn main() {
     let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
-    println!("{}", args);
+    println!("{:?}", args);
 }

--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -47,5 +47,5 @@ fn main() {
     let args: Args = Docopt::new(USAGE)
                             .and_then(|d| d.decode())
                             .unwrap_or_else(|e| e.exit());
-    println!("{}", args);
+    println!("{:?}", args);
 }

--- a/examples/cp.rs
+++ b/examples/cp.rs
@@ -24,5 +24,5 @@ fn main() {
     let args: Args = Docopt::new(USAGE)
                             .and_then(|d| d.decode())
                             .unwrap_or_else(|e| e.exit());
-    println!("{}", args);
+    println!("{:?}", args);
 }

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -24,21 +24,21 @@ Options:
 
 #[derive(RustcDecodable, Show)]
 struct Args {
-    flag_speed: int,
+    flag_speed: isize,
     flag_drifting: bool,
     arg_name: Vec<String>,
-    arg_x: Option<int>,
-    arg_y: Option<int>,
+    arg_x: Option<isize>,
+    arg_y: Option<isize>,
 }
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
                             .and_then(|d| d.decode())
                             .unwrap_or_else(|e| e.exit());
-    println!("{}", args);
+    println!("{:?}", args);
 
     println!("\nSome values:");
     println!("  Speed: {}", args.flag_speed);
     println!("  Drifting? {}", args.flag_drifting);
-    println!("  Names: {}", args.arg_name);
+    println!("  Names: {:?}", args.arg_name);
 }

--- a/examples/hashmap.rs
+++ b/examples/hashmap.rs
@@ -25,7 +25,7 @@ fn main() {
     let args = Docopt::new(USAGE)
                       .and_then(|dopt| dopt.parse())
                       .unwrap_or_else(|e| e.exit());
-    println!("{}", args);
+    println!("{:?}", args);
 
     // You can conveniently access values with `get_{bool,count,str,vec}`
     // functions. If the key doesn't exist (or if, e.g., you use `get_str` on
@@ -33,5 +33,5 @@ fn main() {
     println!("\nSome values:");
     println!("  Speed: {}", args.get_str("--speed"));
     println!("  Drifting? {}", args.get_bool("--drifting"));
-    println!("  Names: {}", args.get_vec("<name>"));
+    println!("  Names: {:?}", args.get_vec("<name>"));
 }

--- a/examples/verbose_multiple.rs
+++ b/examples/verbose_multiple.rs
@@ -25,12 +25,12 @@ struct Args {
     arg_dest: String,
     arg_dir: String,
     flag_archive: bool,
-    flag_verbose: uint,
+    flag_verbose: usize,
 }
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
                             .and_then(|d| d.decode())
                             .unwrap_or_else(|e| e.exit());
-    println!("{}", args);
+    println!("{:?}", args);
 }

--- a/src/synonym.rs
+++ b/src/synonym.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::collections::hash_map::{Iter, Keys};
+use std::collections::hash_map::{Hasher, Iter, Keys};
 use std::fmt::Show;
 use std::hash::Hash;
 use std::iter::FromIterator;
@@ -11,7 +11,7 @@ pub struct SynonymMap<K, V> {
     syns: HashMap<K, K>,
 }
 
-impl<K: Eq + Hash, V> SynonymMap<K, V> {
+impl<K: Eq + Hash<Hasher>, V> SynonymMap<K, V> {
     pub fn new() -> SynonymMap<K, V> {
         SynonymMap {
             vals: HashMap::new(),
@@ -44,7 +44,7 @@ impl<K: Eq + Hash, V> SynonymMap<K, V> {
         self.with_key(k, |k| self.vals.contains_key(k))
     }
 
-    pub fn len(&self) -> uint {
+    pub fn len(&self) -> usize {
         self.vals.len()
     }
 
@@ -57,7 +57,7 @@ impl<K: Eq + Hash, V> SynonymMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone, V> SynonymMap<K, V> {
+impl<K: Eq + Hash<Hasher> + Clone, V> SynonymMap<K, V> {
     pub fn resolve(&self, k: &K) -> K {
         self.with_key(k, |k| k.clone())
     }
@@ -89,7 +89,7 @@ impl<K: Eq + Hash + Clone, V> SynonymMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone, V> FromIterator<(K, V)> for SynonymMap<K, V> {
+impl<K: Eq + Hash<Hasher> + Clone, V> FromIterator<(K, V)> for SynonymMap<K, V> {
     fn from_iter<T: Iterator<Item=(K, V)>>(mut iter: T) -> SynonymMap<K, V> {
         let mut map = SynonymMap::new();
         for (k, v) in iter {
@@ -99,9 +99,9 @@ impl<K: Eq + Hash + Clone, V> FromIterator<(K, V)> for SynonymMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Show, V: Show> Show for SynonymMap<K, V> {
+impl<K: Eq + Hash<Hasher> + Show, V: Show> Show for SynonymMap<K, V> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         try!(self.vals.fmt(f));
-        write!(f, " (synomyns: {})", self.syns.to_string())
+        write!(f, " (synomyns: {:?})", self.syns)
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -25,14 +25,14 @@ fn same_args(expected: &HashMap<String, Value>, got: &ArgvMap) {
         match got.map.find(k) {
             None => panic!("EXPECTED has '{}' but GOT does not.", k),
             Some(vg) => assert!(ve == vg,
-                                "{}: EXPECTED = '{}' != '{}' = GOT", k, ve, vg),
+                                "{}: EXPECTED = '{:?}' != '{:?}' = GOT", k, ve, vg),
         }
     }
     for (k, vg) in got.map.iter() {
         match got.map.find(k) {
             None => panic!("GOT has '{}' but EXPECTED does not.", k),
             Some(ve) => assert!(vg == ve,
-                                "{}: GOT = '{}' != '{}' = EXPECTED", k, vg, ve),
+                                "{}: GOT = '{:?}' != '{:?}' = EXPECTED", k, vg, ve),
         }
     }
 }

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -1,4 +1,5 @@
 #![experimental]
+#![feature(box_syntax)]
 
 extern crate regex;
 extern crate "rustc-serialize" as rustc_serialize;


### PR DESCRIPTION
I have outlined the changes in the commit message.

`#![allow(unstable)]` is required because for some reason the documentation test runner sets `#![deny(unstable)]`.