### PR TITLE
Update Show/String to Debug/Display

### DIFF
--- a/docopt_macros/examples/cp.rs
+++ b/docopt_macros/examples/cp.rs
@@ -5,7 +5,7 @@ extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 #[plugin] #[no_link] extern crate docopt_macros;
 
-docopt!(Args derive Show, "
+docopt!(Args derive Debug, "
 Usage: cp [options] <src> <dst>
        cp [options] <src>... <dir>
        cp --help

--- a/docopt_macros/examples/macro.rs
+++ b/docopt_macros/examples/macro.rs
@@ -5,7 +5,7 @@ extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 #[plugin] #[no_link] extern crate docopt_macros;
 
-docopt!(pub Args derive Show, "
+docopt!(pub Args derive Debug, "
 Naval Fate.
 
 Usage:

--- a/docopt_macros/examples/rustc.rs
+++ b/docopt_macros/examples/rustc.rs
@@ -5,7 +5,7 @@ extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 #[plugin] #[no_link] extern crate docopt_macros;
 
-docopt!(Args derive Show, "
+docopt!(Args derive Debug, "
 Usage: rustc [options] [--cfg SPEC... -L PATH...] INPUT
        rustc (--help | --version)
 
@@ -19,10 +19,10 @@ Options:
     --opt-level LEVEL  Optimize with possible levels 0-3.
 ", flag_opt_level: Option<OptLevel>, flag_emit: Option<Emit>);
 
-#[derive(RustcDecodable, Show)]
+#[derive(Debug, RustcDecodable)]
 enum Emit { Asm, Ir, Bc, Obj, Link }
 
-#[derive(Show)]
+#[derive(Debug)]
 enum OptLevel { Zero, One, Two, Three }
 
 impl rustc_serialize::Decodable for OptLevel {

--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -30,7 +30,7 @@ Some common cargo commands are:
 See 'cargo help <command>' for more information on a specific command.
 ";
 
-#[derive(RustcDecodable, Show)]
+#[derive(Debug, RustcDecodable)]
 struct Args {
     arg_command: Command,
     arg_args: Vec<String>,
@@ -38,7 +38,7 @@ struct Args {
     flag_verbose: bool,
 }
 
-#[derive(RustcDecodable, Show)]
+#[derive(Debug, RustcDecodable)]
 enum Command {
     Build, Clean, Doc, New, Run, Test, Bench, Update,
 }

--- a/examples/cp.rs
+++ b/examples/cp.rs
@@ -12,7 +12,7 @@ Options:
     -a, --archive  Copy everything.
 ";
 
-#[derive(RustcDecodable, Show)]
+#[derive(Debug, RustcDecodable)]
 struct Args {
     arg_source: Vec<String>,
     arg_dest: String,

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -22,7 +22,7 @@ Options:
   --drifting    Drifting mine.
 ";
 
-#[derive(RustcDecodable, Show)]
+#[derive(Debug, RustcDecodable)]
 struct Args {
     flag_speed: isize,
     flag_drifting: bool,

--- a/examples/verbose_multiple.rs
+++ b/examples/verbose_multiple.rs
@@ -19,7 +19,7 @@ Options:
     -v, --verbose  Show extra log output.
 ";
 
-#[derive(RustcDecodable, Show)]
+#[derive(Debug, RustcDecodable)]
 struct Args {
     arg_source: Vec<String>,
     arg_dest: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,13 +126,13 @@
 //! // This is easy. The decoder will automatically restrict values to
 //! // strings that match one of the enum variants.
 //! #[derive(RustcDecodable)]
-//! # #[derive(PartialEq, Show)]
+//! # #[derive(Debug, PartialEq)]
 //! enum Emit { Asm, Ir, Bc, Obj, Link }
 //!
 //! // This one is harder because we want the user to specify an integer,
 //! // but restrict it to a specific range. So we implement `Decodable`
 //! // ourselves.
-//! # #[derive(PartialEq, Show)]
+//! # #[derive(Debug, PartialEq)]
 //! enum OptLevel { Zero, One, Two, Three }
 //!
 //! impl rustc_serialize::Decodable for OptLevel {
@@ -281,7 +281,7 @@ macro_rules! regex(
 ///                   .and_then(|d| d.parse())
 ///                   .unwrap_or_else(|e| e.exit());
 /// ```
-#[derive(Show)]
+#[derive(Debug)]
 pub enum Error {
     /// Parsing the usage string failed.
     ///
@@ -356,7 +356,7 @@ impl Error {
     }
 }
 
-impl fmt::String for Error {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             WithProgramUsage(ref other, ref usage) => {
@@ -389,7 +389,6 @@ impl StdError for Error {
         }
     }
 
-    fn detail(&self) -> Option<String> { Some(self.to_string()) }
     fn cause(&self) -> Option<&StdError> {
         match *self {
             WithProgramUsage(ref cause, _) => Some(&**cause as &StdError),
@@ -418,7 +417,7 @@ impl<'a> StrAllocating for &'a str {
 /// The main Docopt type, which is constructed with a Docopt usage string.
 ///
 /// This can be used to match command line arguments to produce a `ArgvMap`.
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 pub struct Docopt {
     p: Parser,
     argv: Option<Vec<String>>,
@@ -741,7 +740,7 @@ impl ArgvMap {
     }
 }
 
-impl fmt::Show for ArgvMap {
+impl fmt::Debug for ArgvMap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.len() == 0 {
             return write!(f, "{{EMPTY}}");
@@ -776,7 +775,7 @@ impl fmt::Show for ArgvMap {
 ///
 /// The various `as_{bool,count,str,vec}` methods provide convenient access
 /// to values without destructuring manually.
-#[derive(Clone, PartialEq, Show)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Value {
     /// A boolean value from a flag that has no argument.
     ///
@@ -879,7 +878,7 @@ pub struct Decoder {
     stack: Vec<DecoderItem>,
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 struct DecoderItem {
     key: String,
     struct_field: String,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -291,7 +291,7 @@ impl Parser {
     }
 }
 
-impl fmt::Show for Parser {
+impl fmt::Debug for Parser {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         fn sorted<T: Ord>(mut xs: Vec<T>) -> Vec<T> {
             xs.sort(); xs
@@ -585,7 +585,7 @@ impl<'a> PatParser<'a> {
     }
 }
 
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 enum Pattern {
     Alternates(Vec<Pattern>),
     Sequence(Vec<Pattern>),
@@ -594,7 +594,7 @@ enum Pattern {
     PatAtom(Atom),
 }
 
-#[derive(PartialEq, Eq, Ord, Hash, Clone, Show)]
+#[derive(PartialEq, Eq, Ord, Hash, Clone, Debug)]
 pub enum Atom {
     Short(char),
     Long(String),
@@ -602,7 +602,7 @@ pub enum Atom {
     Positional(String),
 }
 
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 pub struct Options {
     /// Set to true if this atom is ever repeated in any context.
     /// For positional arguments, non-argument flags and commands, repetition
@@ -620,7 +620,7 @@ pub struct Options {
     pub is_desc: bool,
 }
 
-#[derive(Clone, Show, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Argument {
     Zero,
     One(Option<String>), // optional default value
@@ -758,7 +758,7 @@ impl PartialOrd for Atom {
     }
 }
 
-impl fmt::String for Atom {
+impl fmt::Display for Atom {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Short(c) => write!(f, "-{}", c),
@@ -809,7 +809,7 @@ pub struct Argv<'a> {
     options_first: bool,
 }
 
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 struct ArgvToken {
     atom: Atom,
     arg: Option<String>,
@@ -929,7 +929,7 @@ impl<'a> Argv<'a> {
     }
 }
 
-impl<'a> fmt::Show for Argv<'a> {
+impl<'a> fmt::Debug for Argv<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         try!(writeln!(f, "Positional: {:?}", self.positional));
         try!(writeln!(f, "Flags: {:?}", self.flags));
@@ -942,7 +942,7 @@ struct Matcher<'a, 'b:'a> {
     argv: &'a Argv<'b>,
 }
 
-#[derive(Clone, PartialEq, Show)]
+#[derive(Clone, Debug, PartialEq)]
 struct MState {
     argvi: usize, // index into Argv.positional
     counts: HashMap<Atom, usize>, // flags remaining for pattern consumption

--- a/src/synonym.rs
+++ b/src/synonym.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::collections::hash_map::{Hasher, Iter, Keys};
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::mem;
@@ -99,7 +99,7 @@ impl<K: Eq + Hash<Hasher> + Clone, V> FromIterator<(K, V)> for SynonymMap<K, V> 
     }
 }
 
-impl<K: Eq + Hash<Hasher> + Show, V: Show> Show for SynonymMap<K, V> {
+impl<K: Eq + Hash<Hasher> + Debug, V: Debug> Debug for SynonymMap<K, V> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         try!(self.vals.fmt(f));
         write!(f, " (synomyns: {:?})", self.syns)

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -45,7 +45,7 @@ Which will only include 'a', 'b' and 'c' in the wordlist if
 'your-command --help' contains a positional argument named 'arg'.
 ";
 
-#[derive(RustcDecodable, Show)]
+#[derive(Debug, RustcDecodable)]
 struct Args {
     arg_name: Vec<String>,
     arg_possibles: Vec<String>,


### PR DESCRIPTION
This commit replaces usage of the `Show` and `fmt::String` traits with the `Debug` and `Display` traits, respectively. This was required to fix breaking changes introduced by rust-lang/rust#21457. Additionally, the superfluous `detail` method on `docopt::Error` was removed as it no longer exists in the trait. Also, hi!