### PR TITLE
Replace io with old_io

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ use Error::{Usage, Argv, NoMatch, Decode, WithProgramUsage, Help, Version};
 
 macro_rules! werr(
     ($($arg:tt)*) => (
-        match std::io::stderr().write_str(&*format!($($arg)*)) {
+        match std::old_io::stderr().write_str(&*format!($($arg)*)) {
             Ok(_) => (),
             Err(err) => panic!("{}", err),
         }

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -8,7 +8,7 @@ extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
 
 use std::collections::HashMap;
-use std::io;
+use std::old_io as io;
 use std::os;
 
 pub use docopt::{Docopt, Value};


### PR DESCRIPTION
Update references to `std::io` with `std::old_io` due to rust-lang/rust#21543.