### PR TITLE
Use options_first(true) in cargo example

### DIFF
--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -45,7 +45,7 @@ enum Command {
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                            .and_then(|d| d.decode())
+                            .and_then(|d| d.options_first(true).decode())
                             .unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 }


### PR DESCRIPTION
Enable  passing option to a subcommand, like `cargo build -h`.