### PR TITLE
Use parse_seq_to_before_end to keep the end token.

### DIFF
--- a/docopt_macros/src/macro.rs
+++ b/docopt_macros/src/macro.rs
@@ -175,15 +175,15 @@ impl<'a, 'b> MacParser<'a, 'b> {
             sep: Some(token::Comma),
             trailing_sep_allowed: true,
         };
-        let types = try!(self.p.parse_seq_to_end(
+        let types = self.p.parse_seq_to_before_end(
             &token::Eof, sep, |p| MacParser::parse_type_annotation(p)
-        )).into_iter()
-          .map(|(ident, ty)| {
+        ).into_iter()
+         .map(|(ident, ty)| {
               let field_name = ident.to_string();
               let key = ArgvMap::struct_field_to_key(&*field_name);
               (Atom::new(&*key), ty)
-           })
-          .collect::<HashMap<Atom, P<ast::Ty>>>();
+          })
+         .collect::<HashMap<Atom, P<ast::Ty>>>();
         try!(self.p.expect(&token::Eof));
 
         // This config does not matter because we're only asking for the


### PR DESCRIPTION
Without this change `parse_seq_to_end` eats the EOF so `expect(Eof)` ICEs under rust-lang/rust#32479.