### PR TITLE
Switch to P::new instead of P::empty

### DIFF
--- a/docopt_macros/src/macro.rs
+++ b/docopt_macros/src/macro.rs
@@ -310,7 +310,7 @@ fn ty_vec_string(cx: &ExtCtxt) -> P<ast::Ty> {
     let tystr = ast::AngleBracketedParameterData {
         lifetimes: vec![],
         types: P::from_vec(vec![cx.ty_ident(sp, ident("String"))]),
-        bindings: P::empty(),
+        bindings: P::new(),
     };
     cx.ty_path(ast::Path {
         span: sp,


### PR DESCRIPTION
This fixes the build for `docopt_macros` for `nightly-2016-04-27` (and maybe earlier versions)