### PR TITLE
Fix parsing default values containing ']'

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -248,7 +248,7 @@ impl Parser {
     }
 
     fn parse_default(&mut self, desc: &str) -> Result<(), String> {
-        let rdefault = regex!(r"\[(?i:default):(?P<val>[^]]*)\]");
+        let rdefault = regex!(r"\[(?i:default):(?P<val>.*)\]");
         let defval =
             match rdefault.captures(desc) {
                 None => return Ok(()),

--- a/src/test/testcases.docopt
+++ b/src/test/testcases.docopt
@@ -1096,3 +1096,15 @@ $ program --speed=-20
 {"--speed": "-20"}
 $ program --speed -20
 {"--speed": "-20"}
+
+#
+# Issue 187: Fails to parse a default value containing ']'
+#
+
+r"""usage: prog [--datetime=<regex>]
+
+options: --datetime=<regex>    Regex for datetimes [default: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}]
+
+"""
+$ prog
+{"--datetime": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"}

--- a/src/test/testcases.rs
+++ b/src/test/testcases.rs
@@ -789,3 +789,7 @@ test_expect!(test_212_testcases, "Usage: prog --speed=ARG", &["--speed=-20"], ve
 
 test_expect!(test_213_testcases, "Usage: prog --speed=ARG", &["--speed", "-20"], vec!(("--speed", Plain(Some("-20".to_string())))));
 
+test_expect!(test_214_testcases, "usage: prog [--datetime=<regex>]
+
+options: --datetime=<regex>    Regex for datetimes [default: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}]", &[], vec!(("--datetime", Plain(Some("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}".to_string())))));
+


### PR DESCRIPTION
This fixes docopt/docopt.rs#187.

I solved the issue by allowing a regex to find a longest matching substring.
Because we don't expect another `']'` after a default value notation "[default: blahblah]", we can simply consider a last`']'` is the closing bracket of the notation.  So, finding the longest matching works here.

I also found that [docopt.py uses the same regex](https://github.com/docopt/docopt/blob/master/docopt.py#L161).