### PR TITLE
Fix issue #195

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -93,5 +93,19 @@ fn regression_issue_12() {
     assert_eq!(dopt.arg_timestamp, 0);
 }
 
+#[test]
+fn regression_issue_195() {
+    const USAGE: &'static str = "
+    Usage:
+        slow [-abcdefghijklmnopqrs...]
+    ";
+
+    let argv = &["slow", "-abcdefghijklmnopqrs"];
+    let dopt : Docopt = Docopt::new(USAGE).unwrap().argv(argv);
+
+    dopt.parse().unwrap();
+}
+
+
 mod testcases;
 mod suggestions;


### PR DESCRIPTION
This should fix the performance issues noted in #195.

I have added special cases for handling `[--flag...]`, `--flag...`, `[--flag]...` and a test case for the issue. There is some code duplication in the fix currently.

---

By the way, I would have use the following cleaner code instead of
nested match if box syntax was in stable:

    &Repeat(box PatAtom(ref a @ Short(_)))
    | &Repeat(box PatAtom(ref a @ Long(_))) => {
        let argv_count = self.argv.counts.get(a)
                             .map_or(0, |&x| x);
        let max_count = base.max_counts.get(a)
                            .map_or(0, |&x| x);
        if argv_count > max_count {
            for _ in max_count..argv_count {
                base.use_optional_flag(a);
            }
        }
    }
