### PR TITLE
Remove seemingly unnecessary Repeat patterns

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -482,10 +482,7 @@ impl<'a> PatParser<'a> {
         let stacked: String = self.cur()[1..].into();
         for (i, c) in stacked.chars().enumerate() {
             let atom = self.dopt.descs.resolve(&Short(c));
-            let mut pat = PatAtom(atom.clone());
-            if self.dopt.has_repeat(&atom) {
-                pat = Pattern::repeat(pat);
-            }
+            let pat = PatAtom(atom.clone());
             seq.push(pat);
 
             // The only way for a short option to have an argument is if
@@ -544,11 +541,7 @@ impl<'a> PatParser<'a> {
         }
         self.add_atom_ifnotexists(arg, &atom);
         self.next();
-        let pat = if self.dopt.has_repeat(&atom) {
-            Pattern::repeat(PatAtom(atom))
-        } else {
-            PatAtom(atom)
-        };
+        let pat = PatAtom(atom);
         Ok(self.maybe_repeat(pat))
     }
 


### PR DESCRIPTION
This should make the tests in PR #185 much faster.

This was the pattern before my change:
```
r"""Usage:
  prog a b [-p <param>]...
  prog a c [-p <type> <param>]...
"""
$ program a c -p bool 1 -p bool 0 -p bool 1
{"-p": 3, "<type>": ["bool", "bool", "bool"], "<param>": ["1", "0", "1"]}

Usages:
  Sequence([PatAtom(Command("a")), PatAtom(Command("b")), Repeat(Optional([PatAtom(Short('p')), PatAtom(Positional("param"))]))])
  Sequence([PatAtom(Command("a")), PatAtom(Command("c")), Repeat(Optional([Repeat(PatAtom(Short('p'))), PatAtom(Positional("type")), PatAtom(Positional("param"))]))])
```

The ```Repeat(Optional([Repeat(...``` causes an explosion in the function ```states```.   ```states``` was being called 1,421,237 times, and producing a vector of 236,975 elements.

This is the pattern after:
```
Usages:
  Sequence([PatAtom(Command("a")), PatAtom(Command("b")), Repeat(Optional([PatAtom(Short('p')), PatAtom(Positional("param"))]))])
  Sequence([PatAtom(Command("a")), PatAtom(Command("c")), Repeat(Optional([PatAtom(Short('p')), PatAtom(Positional("type")), PatAtom(Positional("param"))]))])
```

```states``` is being called 7,843 times, and producing a vector of 2,296 elements.


I'm not sure why the removed code was ever written.  The concept of "has_repeat" means that the short can possibly repeat under some context somewhere, which seems to have a completely separate meaning from the Repeat(...) pattern.  Furthermore, this extra Repeat(...) pattern only affects the second sequence and not the first.  That's because after the first sequence is processed, Short('p') is flagged as something that repeats, which affects only the second sequence.