### PR TITLE
rustup to rustc 1.16.0-nightly (7821a9b99 2017-01-23)

### DIFF
--- a/docopt_macros/src/macro.rs
+++ b/docopt_macros/src/macro.rs
@@ -313,8 +313,8 @@ fn ty_vec_string(cx: &ExtCtxt) -> P<ast::Ty> {
     let sp = codemap::DUMMY_SP;
     let tystr = ast::AngleBracketedParameterData {
         lifetimes: vec![],
-        types: P::from_vec(vec![cx.ty_ident(sp, ident("String"))]),
-        bindings: P::new(),
+        types: vec![cx.ty_ident(sp, ident("String"))],
+        bindings: vec![],
     };
     cx.ty_path(ast::Path {
         span: sp,


### PR DESCRIPTION
See
https://github.com/rust-lang/rust/commit/03620dba25328ee8cc7316cf6d9bad2d0a118ba1
for changes in libsyntax.