### PR TITLE
Migrate from rustc-serialize to serde 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.12.0
+  - 1.15.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ test = false
 [dependencies]
 lazy_static = "0.2"
 regex = "0.2"
-rustc-serialize = "0.3"
+serde = "1.0"
+serde_derive = "1.0"
 strsim = "0.6"

--- a/docopt_macros/Cargo.toml
+++ b/docopt_macros/Cargo.toml
@@ -20,4 +20,5 @@ path = ".."
 version = "0.7.0"
 
 [dev-dependencies]
-rustc-serialize = "0.3"
+serde = "1.0"
+serde_derive = "1.0"

--- a/docopt_macros/examples/add.rs
+++ b/docopt_macros/examples/add.rs
@@ -1,13 +1,14 @@
 #![feature(plugin)]
 #![plugin(docopt_macros)]
 
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 
 extern crate docopt;
 
 docopt!(Args, "Usage: add <x> <y>", arg_x: usize, arg_y: usize);
 
 fn main() {
-    let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
+    let args: Args = Args::docopt().deserialize().unwrap_or_else(|e| e.exit());
     println!("x: {}, y: {}", args.arg_x, args.arg_y);
 }

--- a/docopt_macros/examples/cp.rs
+++ b/docopt_macros/examples/cp.rs
@@ -1,7 +1,8 @@
 #![feature(plugin)]
 #![plugin(docopt_macros)]
 
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 
 extern crate docopt;
 
@@ -16,6 +17,6 @@ Options:
 ");
 
 fn main() {
-    let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
+    let args: Args = Args::docopt().deserialize().unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 }

--- a/docopt_macros/examples/macro.rs
+++ b/docopt_macros/examples/macro.rs
@@ -1,7 +1,8 @@
 #![feature(plugin)]
 #![plugin(docopt_macros)]
 
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 
 extern crate docopt;
 
@@ -25,7 +26,7 @@ Options:
 ", arg_x: Option<usize>, arg_y: Option<usize>, flag_speed: usize);
 
 fn main() {
-    let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
+    let args: Args = Args::docopt().deserialize().unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 
     println!("\nSome values:");

--- a/docopt_macros/examples/rustc.rs
+++ b/docopt_macros/examples/rustc.rs
@@ -1,9 +1,14 @@
 #![feature(plugin)]
 #![plugin(docopt_macros)]
 
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
 
 extern crate docopt;
+
+use serde::de;
+use std::fmt;
 
 docopt!(Args derive Debug, "
 Usage: rustc [options] [--cfg SPEC... -L PATH...] INPUT
@@ -19,26 +24,58 @@ Options:
     --opt-level LEVEL  Optimize with possible levels 0-3.
 ", flag_opt_level: Option<OptLevel>, flag_emit: Option<Emit>);
 
-#[derive(Debug, RustcDecodable)]
-enum Emit { Asm, Ir, Bc, Obj, Link }
+#[derive(Debug, Deserialize)]
+enum Emit {
+    Asm,
+    Ir,
+    Bc,
+    Obj,
+    Link,
+}
 
 #[derive(Debug)]
-enum OptLevel { Zero, One, Two, Three }
+enum OptLevel {
+    Zero,
+    One,
+    Two,
+    Three,
+}
 
-impl rustc_serialize::Decodable for OptLevel {
-    fn decode<D: rustc_serialize::Decoder>(d: &mut D) -> Result<OptLevel, D::Error> {
-        Ok(match try!(d.read_usize()) {
-            0 => OptLevel::Zero, 1 => OptLevel::One,
-            2 => OptLevel::Two, 3 => OptLevel::Three,
+struct OptLevelVisitor;
+
+impl<'de> de::Visitor<'de> for OptLevelVisitor {
+    type Value = OptLevel;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an integer between 0 and 3")
+    }
+
+    fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
+        where E: de::Error
+    {
+        let level = match value {
+            0 => OptLevel::Zero,
+            1 => OptLevel::One,
+            2 => OptLevel::Two,
+            3 => OptLevel::Three,
             n => {
-                let err = format!("Could not decode '{}' as opt-level.", n);
-                return Err(d.error(&*err));
+                let err = format!("Could not deserialize '{}' as opt-level.", n);
+                return Err(E::custom(err));
             }
-        })
+        };
+        Ok(level)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for OptLevel {
+    fn deserialize<D>(deserializer: D) -> Result<OptLevel, D::Error>
+        where D: de::Deserializer<'de>
+    {
+        deserializer.deserialize_u8(OptLevelVisitor)
     }
 }
 
 fn main() {
-    let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
+    let args: Args = Args::docopt().deserialize().unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 }

--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -1,4 +1,5 @@
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 extern crate docopt;
 
 use docopt::Docopt;
@@ -30,7 +31,7 @@ Some common cargo commands are:
 See 'cargo help <command>' for more information on a specific command.
 ";
 
-#[derive(Debug, RustcDecodable)]
+#[derive(Debug, Deserialize)]
 struct Args {
     arg_command: Option<Command>,
     arg_args: Vec<String>,
@@ -38,14 +39,21 @@ struct Args {
     flag_verbose: bool,
 }
 
-#[derive(Debug, RustcDecodable)]
+#[derive(Debug, Deserialize)]
 enum Command {
-    Build, Clean, Doc, New, Run, Test, Bench, Update,
+    Build,
+    Clean,
+    Doc,
+    New,
+    Run,
+    Test,
+    Bench,
+    Update,
 }
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                            .and_then(|d| d.options_first(true).decode())
-                            .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.options_first(true).deserialize())
+        .unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 }

--- a/examples/cp.rs
+++ b/examples/cp.rs
@@ -1,4 +1,5 @@
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 extern crate docopt;
 
 use docopt::Docopt;
@@ -12,7 +13,7 @@ Options:
     -a, --archive  Copy everything.
 ";
 
-#[derive(Debug, RustcDecodable)]
+#[derive(Debug, Deserialize)]
 struct Args {
     arg_source: Vec<String>,
     arg_dest: String,
@@ -22,7 +23,7 @@ struct Args {
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                            .and_then(|d| d.decode())
-                            .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 }

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,4 +1,5 @@
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 extern crate docopt;
 
 use docopt::Docopt;
@@ -22,7 +23,7 @@ Options:
   --drifting    Drifting mine.
 ";
 
-#[derive(Debug, RustcDecodable)]
+#[derive(Debug, Deserialize)]
 struct Args {
     flag_speed: isize,
     flag_drifting: bool,
@@ -35,8 +36,8 @@ struct Args {
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                            .and_then(|d| d.decode())
-                            .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 
     println!("\nSome values:");

--- a/examples/optional_command.rs
+++ b/examples/optional_command.rs
@@ -4,11 +4,14 @@
 // decoder uses `Option<T>` to mean "T may not be present" rather than
 // "T may be present but incorrect."
 
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
 extern crate docopt;
 
 use docopt::Docopt;
-use rustc_serialize::{Decodable, Decoder};
+use serde::de::{Deserialize, Deserializer, Error, Visitor};
+use std::fmt;
 
 // Write the Docopt usage string.
 const USAGE: &'static str = "
@@ -21,30 +24,53 @@ Options:
     -h, --help       Display this message
 ";
 
-#[derive(Debug, RustcDecodable)]
+#[derive(Debug, Deserialize)]
 struct Args {
     arg_command: Command,
 }
 
-impl Decodable for Command {
-    fn decode<D: Decoder>(d: &mut D) -> Result<Command, D::Error> {
-        let s = try!(d.read_str());
-        Ok(match &*s {
-            "" => Command::None,
-            "A" => Command::A,
-            "B" => Command::B,
-            "C" => Command::C,
-            s => Command::Unknown(s.to_string()),
-        })
+struct CommandVisitor;
+
+impl<'de> Visitor<'de> for CommandVisitor {
+    type Value = Command;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string A, B or C")
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where E: Error
+    {
+        Ok(match s {
+               "" => Command::None,
+               "A" => Command::A,
+               "B" => Command::B,
+               "C" => Command::C,
+               s => Command::Unknown(s.to_string()),
+           })
+    }
+}
+
+impl<'de> Deserialize<'de> for Command {
+    fn deserialize<D>(d: D) -> Result<Command, D::Error>
+        where D: Deserializer<'de>
+    {
+        d.deserialize_str(CommandVisitor)
     }
 }
 
 #[derive(Debug)]
-enum Command { A, B, C, Unknown(String), None }
+enum Command {
+    A,
+    B,
+    C,
+    Unknown(String),
+    None,
+}
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                            .and_then(|d| d.decode())
-                            .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 }

--- a/examples/verbose_multiple.rs
+++ b/examples/verbose_multiple.rs
@@ -1,4 +1,5 @@
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 extern crate docopt;
 
 use docopt::Docopt;
@@ -19,7 +20,7 @@ Options:
     -v, --verbose  Show extra log output.
 ";
 
-#[derive(Debug, RustcDecodable)]
+#[derive(Debug, Deserialize)]
 struct Args {
     arg_source: Vec<String>,
     arg_dest: String,
@@ -30,7 +31,7 @@ struct Args {
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                            .and_then(|d| d.decode())
-                            .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     println!("{:?}", args);
 }

--- a/src/synonym.rs
+++ b/src/synonym.rs
@@ -101,7 +101,7 @@ impl<K: Eq + Hash + Clone, V> FromIterator<(K, V)> for SynonymMap<K, V> {
 
 impl<K: Eq + Hash + Debug, V: Debug> Debug for SynonymMap<K, V> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        try!(self.vals.fmt(f));
+        self.vals.fmt(f)?;
         write!(f, " (synomyns: {:?})", self.syns)
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -78,18 +78,20 @@ fn regression_issue_12() {
         whisper mark <file> <value>
     ";
 
-    #[derive(RustcDecodable, Debug)]
+    #[derive(Deserialize, Debug)]
     struct Args {
         arg_file: String,
         cmd_info: bool,
         cmd_update: bool,
         arg_timestamp: u64,
-        arg_value: f64
+        arg_value: f64,
     }
 
-    let dopt: Args = Docopt::new(USAGE).unwrap()
-                            .argv(&["whisper", "mark", "./p/blah", "100"])
-                            .decode().unwrap();
+    let dopt: Args = Docopt::new(USAGE)
+        .unwrap()
+        .argv(&["whisper", "mark", "./p/blah", "100"])
+        .deserialize()
+        .unwrap();
     assert_eq!(dopt.arg_timestamp, 0);
 }
 

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -1,7 +1,11 @@
 #[macro_use]
 extern crate lazy_static;
+
+#[macro_use]
+extern crate serde_derive;
+
 extern crate regex;
-extern crate rustc_serialize;
+extern crate serde;
 extern crate strsim;
 
 use std::collections::HashMap;
@@ -53,7 +57,7 @@ Which will only include 'a', 'b' and 'c' in the wordlist if
 'your-command --help' contains a positional argument named 'arg'.
 ";
 
-#[derive(Debug, RustcDecodable)]
+#[derive(Debug, Deserialize)]
 struct Args {
     arg_name: Vec<String>,
     arg_possibles: Vec<String>,
@@ -61,8 +65,8 @@ struct Args {
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                            .and_then(|d| d.decode())
-                            .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(args) {
         Ok(_) => {},
         Err(err) => {
@@ -74,8 +78,8 @@ fn main() {
 
 fn run(args: Args) -> Result<(), String> {
     let mut usage = String::new();
-    try!(io::stdin().read_to_string(&mut usage).map_err(|e| e.to_string()));
-    let parsed = try!(Parser::new(&usage).map_err(|e| e.to_string()));
+    io::stdin().read_to_string(&mut usage).map_err(|e| e.to_string())?;
+    let parsed = Parser::new(&usage).map_err(|e| e.to_string())?;
     let arg_possibles: HashMap<String, Vec<String>> =
         args.arg_name.iter()
                      .zip(args.arg_possibles.iter())


### PR DESCRIPTION
This is a breaking change.
* decode() is renamed to deserialize()
  for consistency with serde
* docopt_macros is updated to latest nightly

Fixes #128, #213 