### PR TITLE
Simplify rustc example, update version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ This crate is fully compatible with Cargo. Just add it to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-docopt = "0.7"
+docopt = "0.8"
 serde_derive = "1.0" # if you're using `derive(Deserialize)`
 ```
 
-If you want to use the macro, then add `docopt_macros = "0.7"` instead.
+If you want to use the macro, then add `docopt_macros = "0.8"` instead.
 Note that the **`docopt!` macro only works on a nightly Rust compiler** because
 it is a compiler plugin.
 

--- a/docopt_macros/examples/rustc.rs
+++ b/docopt_macros/examples/rustc.rs
@@ -8,7 +8,6 @@ extern crate serde;
 extern crate docopt;
 
 use serde::de;
-use std::fmt;
 
 docopt!(Args derive Debug, "
 Usage: rustc [options] [--cfg SPEC... -L PATH...] INPUT
@@ -41,37 +40,22 @@ enum OptLevel {
     Three,
 }
 
-struct OptLevelVisitor;
-
-impl<'de> de::Visitor<'de> for OptLevelVisitor {
-    type Value = OptLevel;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("an integer between 0 and 3")
-    }
-
-    fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
-        where E: de::Error
+impl<'de> de::Deserialize<'de> for OptLevel {
+    fn deserialize<D>(deserializer: D) -> Result<OptLevel, D::Error>
+        where D: de::Deserializer<'de>
     {
-        let level = match value {
+        let level = match u8::deserialize(deserializer)? {
             0 => OptLevel::Zero,
             1 => OptLevel::One,
             2 => OptLevel::Two,
             3 => OptLevel::Three,
             n => {
-                let err = format!("Could not deserialize '{}' as opt-level.", n);
-                return Err(E::custom(err));
+                let value = de::Unexpected::Unsigned(n as u64);
+                let msg = "expected an integer between 0 and 3";
+                return Err(de::Error::invalid_value(value, &msg));
             }
         };
         Ok(level)
-    }
-}
-
-impl<'de> de::Deserialize<'de> for OptLevel {
-    fn deserialize<D>(deserializer: D) -> Result<OptLevel, D::Error>
-        where D: de::Deserializer<'de>
-    {
-        deserializer.deserialize_u8(OptLevelVisitor)
     }
 }
 


### PR DESCRIPTION
I didn't manage to simplify examples/optional_command.rs the same way
(using <&str as Deserialize<'de>>::deserialize(d)),
because of runtime error on this example:
```
invalid type: string "A", expected a borrowed string 
```