### PR TITLE
removed repeat normalize, fixed #219

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -759,8 +759,6 @@ impl Pattern {
 
     fn repeat(p: Pattern) -> Pattern {
         match p {
-            // Normalize [p1 p2]... into the equivalent [p1... p2...].
-            Optional(ps) => Optional(ps.into_iter().map(Pattern::repeat).collect()),
             p @ Repeat(_) => p,
             p => Repeat(Box::new(p)),
         }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -109,6 +109,25 @@ fn regression_issue_195() {
 }
 
 #[test]
+fn regression_issue_219() {
+    #[derive(Deserialize)]
+    struct Args {
+        arg_type: Vec<String>,
+        arg_param: Vec<String>,
+    }
+
+    const USAGE: &'static str = "
+    Usage:
+        encode [-v <type> <param>]...
+    ";
+
+    let argv = &["encode", "-v", "bool", "true", "string", "foo"];
+    let args: Args = Docopt::new(USAGE).unwrap().argv(argv).deserialize().unwrap();
+    assert_eq!(args.arg_type, vec!["bool".to_owned(), "string".to_owned()]);
+    assert_eq!(args.arg_param, vec!["true".to_owned(), "foo".to_owned()]);
+}
+
+#[test]
 fn test_unit_struct() {
     const USAGE: &'static str = "
     Usage:


### PR DESCRIPTION
fixes #219 by removing `normalize` added in [#200](https://github.com/docopt/docopt.rs/pull/200/files#diff-258c0555e6f9c4bc4fba3a551d81638aR763)

cc: @anka-213 