### PR TITLE
Add serde as dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This crate is fully compatible with Cargo. Just add it to your `Cargo.toml`:
 ```toml
 [dependencies]
 docopt = "0.8"
-serde = "1.0"
+serde = "1.0" # if you're using `derive(Deserialize)`
 serde_derive = "1.0" # if you're using `derive(Deserialize)`
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This crate is fully compatible with Cargo. Just add it to your `Cargo.toml`:
 ```toml
 [dependencies]
 docopt = "0.8"
+serde = "1.0"
 serde_derive = "1.0" # if you're using `derive(Deserialize)`
 ```
 


### PR DESCRIPTION
Otherwise, when copying the example as it is from README.md the following weird error occures

```
$ cargo run
    Compiling test v0.1.0 (file:///home/.../test)
error[E0463]: can't find crate for `_serde`
  --> src/main.rs:26:17
   |
26 | #[derive(Debug, Deserialize)]
   |                 ^^^^^^^^^^^ can't find crate

error: aborting due to previous error
```