### PR TITLE
Fix `deserialize` type bounds

### DIFF
--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -208,8 +208,8 @@ impl Docopt {
     ///
     /// For details on how decoding works, please see the documentation for
     /// `ArgvMap`.
-    pub fn deserialize<'a, 'de: 'a, D>(&'a self) -> Result<D>
-        where D: de::Deserialize<'de>
+    pub fn deserialize<D>(&self) -> Result<D>
+        where D: de::DeserializeOwned
     {
         self.parse().and_then(|vals| vals.deserialize())
     }
@@ -392,7 +392,7 @@ impl ArgvMap {
     ///
     /// In this example, only the `bool` type was used, but any type satisfying
     /// the `Deserialize` trait is valid.
-    pub fn deserialize<'de, T: de::Deserialize<'de>>(self) -> Result<T> {
+    pub fn deserialize<T: de::DeserializeOwned>(self) -> Result<T> {
         de::Deserialize::deserialize(&mut Deserializer {
                                               vals: self,
                                               stack: vec![],
@@ -641,9 +641,9 @@ impl Value {
 /// extern crate serde;
 /// # fn main() {
 /// use docopt::Docopt;
-/// use serde::de::Deserialize;
+/// use serde::de::DeserializeOwned;
 ///
-/// fn deserialize<'de, D: Deserialize<'de>>(usage: &str, argv: &[&str])
+/// fn deserialize<D: DeserializeOwned>(usage: &str, argv: &[&str])
 ///                         -> Result<D, docopt::Error> {
 ///     Docopt::new(usage)
 ///            .and_then(|d| d.argv(argv.iter()).deserialize())


### PR DESCRIPTION
The deserializer in Docopt currently does not support deserializing to types that borrow strings/bytes, resulting in error messages like [this](https://github.com/serde-rs/serde/issues/987).

This PR proposes a change to the type bounds of the couple of `deserialize` functions so that only types that do not borrow data can be deserialized. 

This will break existing code that try to deserialize to structs that borrow data (like the example below), but these code would never have run anyway. Existing code that deserializes to types that do not try to borrow data should not break.

Consider the following example:

```rust
#[macro_use]
extern crate serde_derive;
extern crate docopt;

use docopt::Docopt;

const USAGE: &'static str = "
Simple borrowing

Usage:
  borrow <name>

Options:
  -h --help     Show this screen.
";

#[derive(Debug, Deserialize)]
struct Args<'a> {
    arg_name: &'a str
}

fn main() {
    let args: Args = Docopt::new(USAGE)
        .and_then(|d| d.deserialize())
        .unwrap_or_else(|e| e.exit());
    println!("{:?}", args);
}
```

Currently, we will get a weird error when we do `cargo run test`: `invalid type: string "testing", expected a borrowed string`. But this is only discovered at runtime.

With this PR, this code will now not compile: 

```
error[E0279]: the requirement `for<'de> 'de : ` is not satisfied (`expected bound lifetime parameter 'de, found concrete
 lifetime`)
  --> examples/borrowed.rs:24:25
   |
24 |         .and_then(|d| d.deserialize())
   |                         ^^^^^^^^^^^
   |
   = note: required because of the requirements on the impl of `for<'de> _IMPL_DESERIALIZE_FOR_Args::_serde::Deserialize
<'de>` for `Args<'_>`
   = note: required because of the requirements on the impl of `_IMPL_DESERIALIZE_FOR_Args::_serde::de::DeserializeOwned
` for `Args<'_>`
```

