### PR TITLE
Add missing moored flag in Args struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Options:
 #[derive(Debug, Deserialize)]
 struct Args {
     flag_speed: isize,
+    flag_moored: bool,
     flag_drifting: bool,
     arg_name: Vec<String>,
     arg_x: Option<i32>,


### PR DESCRIPTION
Was slightly confusing for me when trying to understand the example but couldn't find the `moored` flag in the struct.