### PR TITLE
update regex deb for minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ test = false
 
 [dependencies]
 lazy_static = "1"
-regex = "1"
+regex = "1.0.3"
 serde = "1.0"
 serde_derive = "1.0"
 strsim = "0.7"


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that are compatible with `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI, specifically upstreaming the changes required to get criterion working with it. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them.

cc @BurntSushi follow up to our discussion at https://github.com/rust-lang/regex/pull/504