### PR TITLE
add minimal-versions to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ rust:
   - stable
   - beta
   - nightly
+before_script:
+  - rustup toolchain install nightly
 script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc
+  - cargo +nightly generate-lockfile -Z minimal-versions
+  - cargo build --verbose
+  - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ rust:
   - stable
   - beta
   - nightly
-before_script:
-  - rustup toolchain install nightly
 script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc
-  - cargo +nightly generate-lockfile -Z minimal-versions
-  - cargo build --verbose
-  - cargo test --verbose
+  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+    cargo +nightly generate-lockfile -Z minimal-versions;
+    cargo build --verbose;
+    cargo test --verbose;
+    fi


### PR DESCRIPTION
This starts work on the [request ](https://github.com/docopt/docopt.rs/pull/241#issuecomment-415872014) to add minimal-versions to CI.

This tests all configuration with `minimal-versions` which is a very aggressive testing resheam. But is a place to start the conversation, and seemed to be easy to do with the way travis is set up.