### PR TITLE
Add an Ergonomics Override for `version()`

### DIFF
--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -307,7 +307,7 @@ impl Docopt {
     /// ```
     /// # extern crate docopt;
     /// # fn main() {
-    /// use docopt::{Docopt, Error::*};
+    /// use docopt::Docopt;
     ///
     /// const USAGE: &'static str = "
     /// Usage: cargo [--version] [--help]

--- a/src/dopt.rs
+++ b/src/dopt.rs
@@ -301,8 +301,35 @@ impl Docopt {
     ///
     /// When disabled (a `None` value), there is no special handling of
     /// `--version`.
-    pub fn version(mut self, version: Option<String>) -> Docopt {
-        self.version = version;
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate docopt;
+    /// # fn main() {
+    /// use docopt::{Docopt, Error::*};
+    ///
+    /// const USAGE: &'static str = "
+    /// Usage: cargo [--version] [--help]
+    ///
+    /// Options: -V, --version
+    ///          -h, --help
+    /// ";
+    ///
+    /// let argv = || vec!["cargo", "--version"].into_iter();
+    /// let err = Docopt::new(USAGE)
+    ///                   .and_then(|d| d
+    ///                      .argv(argv())
+    ///                      .version(String::from("v2.1"))
+    ///                      .parse())
+    ///                   .unwrap_err();
+    ///
+    /// // The returned error contains our version number
+    /// assert_eq!("v2.1", format!("{}", err));
+    /// # }
+    /// ```
+    pub fn version<V: Into<Option<String>>>(mut self, version: V) -> Docopt {
+        self.version = version.into();
         self
     }
 


### PR DESCRIPTION
When setting the version it would be nice not to have to wrap the
string in `Some(..)`. This moves to use the `Into` type to accept
plain version strings in addition to `None` and `Some(..)`.

This means you can now set the version like this:

```rust
d.version(format!("v{}.{}", major, minor))
```

The version string doesn't need to be wrapped in a `Some` any
more. I think the types accepted by this should be a superset of
what the old method accepted. Not sure if this might cause type
inference to fail in some places that it didn't previously though. 